### PR TITLE
Register DNS for Ingress/Services Using ALIAS type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - curl
 
 env:
-  - DOCKER_IMAGE_NAME=cloudposse/route53-kubernetess
+  - DOCKER_IMAGE_NAME=cloudposse/route53-kubernetes
 
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
 env:
   - DOCKER_IMAGE_NAME=cloudposse/route53-kubernetess
 
+
 services:
 - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,62 @@
+sudo: required
+language: go
+
+go:
+- 1.7.x
+
+addons:
+  apt:
+    packages:
+    - git
+    - make
+    - curl
+
+env:
+  - DOCKER_IMAGE_NAME=cloudposse/route53-kubernetes-ingress
+
+services:
+- docker
+
+install:
+- curl https://glide.sh/get | sh
+- make deps
+- |-
+  docker login \
+    --email="$DOCKER_HUB_EMAIL" \
+    --username="$DOCKER_HUB_USERNAME" \
+    --password="$DOCKER_HUB_PASSWORD"
+
+script:
+- make build
+- docker build -t $DOCKER_IMAGE_NAME .
+
+after_success:
+- |-
+  if [ ! -z "$TRAVIS_TAG" ]; then \
+    docker tag $DOCKER_IMAGE_NAME  $DOCKER_IMAGE_NAME:$TRAVIS_TAG &&  \
+    docker push $DOCKER_IMAGE_NAME:$TRAVIS_TAG; \
+  fi
+
+- |-
+  if [ ! -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then \
+    docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE_NAME:pr-$TRAVIS_PULL_REQUEST_BRANCH && \
+    docker push $DOCKER_IMAGE_NAME:pr-$TRAVIS_PULL_REQUEST_BRANCH; \
+  fi
+
+- |-
+  if [[ -z "$TRAVIS_PULL_REQUEST_BRANCH" && ! -z "$TRAVIS_BRANCH" ]]; then \
+    docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE_NAME:$TRAVIS_BRANCH && \
+    docker push $DOCKER_IMAGE_NAME:$TRAVIS_BRANCH; \
+  fi
+
+- |-
+  if [[ -z "$TRAVIS_TAG"  &&  -z "$TRAVIS_PULL_REQUEST_BRANCH"  &&  -z "$TRAVIS_BRANCH" ]]; then \
+    docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE_NAME:latest && \
+    docker push $DOCKER_IMAGE_NAME:latest; \
+  fi
+
+- |-
+  if [[ -z "$TRAVIS_PULL_REQUEST_BRANCH" ]]  && [[ "$TRAVIS_BRANCH" == "master" ]]; then \
+    docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE_NAME:latest && \
+    docker push $DOCKER_IMAGE_NAME:latest; \
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - curl
 
 env:
-  - DOCKER_IMAGE_NAME=cloudposse/route53-kubernetes-ingress
+  - DOCKER_IMAGE_NAME=cloudposse/route53-kubernetess
 
 services:
 - docker

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+GLIDE	:= $(shell which glide)
 GO=CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go
 TAG=v1.3.0
 BIN=route53-kubernetes
@@ -7,7 +8,10 @@ all: image
 	docker push $(IMAGE):$(TAG)
 
 build:
-	$(GO) build -a -installsuffix cgo -o $(BIN) .
+	$(GO) build -installsuffix cgo -o $(BIN) .
+
+deps:
+	$(GLIDE) install --strip-vendor --strip-vcs
 
 image: build
 	docker build -t $(IMAGE):$(TAG) .

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ spec:
   type: LoadBalancer
 ```
 
-An "CNAME" record for `test.mydomain.com` will be created points to the ELB that is
-configured by kubernetes. This assumes that a hosted zone exists in Route53 for mydomain.com.
+A "CNAME" record for `test.mydomain.com` will be created which points to the ELB that is
+configured by kubernetes. This assumes that a hosted zone exists in Route53 for `mydomain.com`.
 Any record that previously existed for that dns record will be updated.
 
 ``dnsRecordType`` and ``dnsRecordTTL`` annotations are optional.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ spec:
               value: ingress=endpoint
             - name: DNS_RECORD_TYPE
               value: CNAME
+            - name: DNS_RECORD_TTL
+              value: 300
 ```
 
 This service expects that it's running on a Kubernetes node on AWS and that the IAM profile for
@@ -72,7 +74,7 @@ that node is set up to allow the following, along with the default permissions n
 
 Service support ingress k8s resources.
 Because nginx ingress controller create on service for all ingress resources
-we use selector (configurable with ``INGRESS_SERVICE_SELECTOR`` environment variables)
+we use selector (configurable with ``INGRESS_SERVICE_SELECTOR`` environment variable)
 to find valid k8s service.
 
 **Default selector**: ``ingress=endpoint``
@@ -81,8 +83,15 @@ to find valid k8s service.
 
 Service support "A" and "CNAME" record types.
 By default service create "A" record for each domain record.
-To specify default record type use ``DNS_RECORD_TYPE`` environment variables.
+To specify default record type use ``DNS_RECORD_TYPE`` environment variable.
 Each k8s service \ ingress can override dns record type by annotation.
+
+#### DNS resource TTL
+
+Service support TTL (in seconds) configuration for dns records.
+Default value is `300` seconds.
+Default value can be overridden with ``DNS_RECORD_TTL`` environment variable.
+You can use annotation ``dnsRecordType`` to provide service \ ingress  specific ttl value.
 
 ### Service Configuration
 
@@ -100,6 +109,7 @@ metadata:
   annotations:
     domainName: "test.mydomain.com"
     dnsRecordType: "CNAME"
+    dnsRecordTTL: 600
 spec:
   selector:
     app: my-app
@@ -120,7 +130,7 @@ An "CNAME" record for `test.mydomain.com` will be created points to the ELB that
 configured by kubernetes. This assumes that a hosted zone exists in Route53 for mydomain.com.
 Any record that previously existed for that dns record will be updated.
 
-``dnsRecordType`` annotation is optional.
+``dnsRecordType`` and ``dnsRecordTTL`` annotations are optional.
 
 ### Ingress Configuration
 
@@ -136,6 +146,7 @@ metadata:
   annotations:
     domainName: "test.mydomain.com"
     dnsRecordType: "A"
+    dnsRecordTTL: 300
 spec:
   backend:
     serviceName: testsvc
@@ -146,7 +157,7 @@ An "A" record for `test.mydomain.com` will be created as an alias to the ELB tha
 ingress controller service by kubernetes. This assumes that a hosted zone exists in Route53 for mydomain.com.
 Any record that previously existed for that dns record will be updated.
 
-``dnsRecordType`` annotation is optional.
+``dnsRecordType`` and ``dnsRecordTTL`` annotations are optional.
 
 ### Alternative setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes => Route53 Mapping Service
 
-This is a Kubernetes service that polls services (in all namespaces) that are configured
+This is a Kubernetes service that polls services and ingresses (in all namespaces) that are configured
 with the label `dns=route53` and adds the appropriate alias to the domain specified by
 the annotation `domainName=sub.mydomain.io`. Multiple domains and top level domains are also supported:
 `domainName=.mydomain.io,sub1.mydomain.io,sub2.mydomain.io`
@@ -35,6 +35,11 @@ spec:
       containers:
         - image: quay.io/molecule/route53-kubernetes:v1.3.0
           name: route53-kubernetes
+          env:
+            - name: INGRESS_SERVICE_SELECTOR
+              value: ingress=endpoint
+            - name: DNS_RECORD_TYPE
+              value: CNAME
 ```
 
 This service expects that it's running on a Kubernetes node on AWS and that the IAM profile for
@@ -63,6 +68,22 @@ that node is set up to allow the following, along with the default permissions n
 }
 ```
 
+#### Ingress support
+
+Service support ingress k8s resources.
+Because nginx ingress controller create on service for all ingress resources
+we use selector (configurable with ``INGRESS_SERVICE_SELECTOR`` environment variables)
+to find valid k8s service.
+
+**Default selector**: ``ingress=endpoint``
+
+#### DNS resource type
+
+Service support "A" and "CNAME" record types.
+By default service create "A" record for each domain record.
+To specify default record type use ``DNS_RECORD_TYPE`` environment variables.
+Each k8s service \ ingress can override dns record type by annotation.
+
 ### Service Configuration
 
 Given the following Kubernetes service definition:
@@ -78,6 +99,7 @@ metadata:
     dns: route53
   annotations:
     domainName: "test.mydomain.com"
+    dnsRecordType: "CNAME"
 spec:
   selector:
     app: my-app
@@ -94,10 +116,37 @@ spec:
   type: LoadBalancer
 ```
 
-An "A" record for `test.mydomain.com` will be created as an alias to the ELB that is
+An "CNAME" record for `test.mydomain.com` will be created points to the ELB that is
 configured by kubernetes. This assumes that a hosted zone exists in Route53 for mydomain.com.
 Any record that previously existed for that dns record will be updated.
 
+``dnsRecordType`` annotation is optional.
+
+### Ingress Configuration
+
+Given the following Kubernetes ingress definition:
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  labels:
+    dns: route53
+  annotations:
+    domainName: "test.mydomain.com"
+    dnsRecordType: "A"
+spec:
+  backend:
+    serviceName: testsvc
+    servicePort: 80
+```
+
+An "A" record for `test.mydomain.com` will be created as an alias to the ELB that is used by
+ingress controller service by kubernetes. This assumes that a hosted zone exists in Route53 for mydomain.com.
+Any record that previously existed for that dns record will be updated.
+
+``dnsRecordType`` annotation is optional.
 
 ### Alternative setup
 

--- a/service_listener.go
+++ b/service_listener.go
@@ -35,7 +35,7 @@ const (
 type rule struct {
 	service       	*api.Service
 	dnsRecordType 	string
-	ttl 		int
+	ttl 		int64
 }
 
 func init() {
@@ -267,7 +267,7 @@ func defaultDNSRecordType() string {
 	return dnsRecordType
 }
 
-func defaultDNSRecordTTL() int {
+func defaultDNSRecordTTL() int64 {
 	ttl := parseTTL(os.Getenv("DNS_RECORD_TTL"))
 	if ttl == 0  {
 		ttl = 300
@@ -280,14 +280,14 @@ func isDNSRecordTypeValid(dnsRecordType string) bool {
 }
 
 
-func parseTTL(ttl string) int {
+func parseTTL(ttl string) int64 {
 	result, err := strconv.Atoi(ttl)
 	if err != nil {
 		return 0
 	} else if result <= 0 {
 		return 0
 	}
-	return result
+	return int64(result)
 }
 
 func getIngressService(c *client.Client)*api.Service {
@@ -455,7 +455,7 @@ func updateDNS(r53Api *route53.Route53, zoneID string, rrs route53.ResourceRecor
 	return nil
 }
 
-func makeATypeRecordSet(hn, hzID, domain string, ttl int) route53.ResourceRecordSet {
+func makeATypeRecordSet(hn, hzID, domain string, ttl int64) route53.ResourceRecordSet {
 	at := route53.AliasTarget{
 		DNSName:              &hn,
 		EvaluateTargetHealth: aws.Bool(false),
@@ -469,7 +469,7 @@ func makeATypeRecordSet(hn, hzID, domain string, ttl int) route53.ResourceRecord
 	}
 }
 
-func makeCNAMETypeRecordSet(hn, hzID, domain string, ttl int) route53.ResourceRecordSet {
+func makeCNAMETypeRecordSet(hn, hzID, domain string, ttl int64) route53.ResourceRecordSet {
 	return route53.ResourceRecordSet{
 		ResourceRecords: []*route53.ResourceRecord{
 			&route53.ResourceRecord{

--- a/service_listener.go
+++ b/service_listener.go
@@ -260,7 +260,7 @@ func getIngressService(c *client.Client)*api.Service {
 		selector = "ingress=endpoint"
 	}
 
-	glog.Infof("User selector %v to find service for ingress", selector)
+	glog.Infof("Using selector %v to find service for ingress", selector)
 
 	l, err := labels.Parse(selector)
 	if err != nil {
@@ -273,7 +273,7 @@ func getIngressService(c *client.Client)*api.Service {
 
 	services, err := c.Services(api.NamespaceAll).List(serviceListOptions)
 	if err != nil || len(services.Items) == 0 {
-		glog.Fatalf("Failed to list services that used for ingress: %v", err)
+		glog.Fatalf("Failed to list services that use ingress: %v", err)
 		return nil
 	}
 

--- a/service_listener.go
+++ b/service_listener.go
@@ -159,6 +159,9 @@ func main() {
 			if err = updateDNS(r53Api, zoneID, rrs); err != nil {
 				glog.Warning(err)
 				continue
+			// If no error and it was dryRun then log info about this
+			} else if dryRun {
+				glog.Infof("DRY RUN: We normally would have updated %s to point %s to %s (%s)", zoneID, domain, hn, elbZoneID)
 			}
 
 			glog.Infof("Created dns record set: domain=%s, zoneID=%s", domain, zoneID)
@@ -404,8 +407,8 @@ func updateDNS(r53Api *route53.Route53, zoneID string, rrs route53.ResourceRecor
 		ChangeBatch:  &batch,
 		HostedZoneId: &zoneID,
 	}
+
 	if dryRun {
-		glog.Infof("DRY RUN: We normally would have updated %s to point to %s (%s)", zoneID)
 		return nil
 	}
 


### PR DESCRIPTION
## what
* Added CNAME support
* Added Ingress support
* Use `ALIAS` for ELBs

## why
* To support Lets Encrypt requirement of A records for all certificates

## who
@cloudposse/engineering 