### PR TITLE
Fix services pass-by-reference issue

### DIFF
--- a/service_listener.go
+++ b/service_listener.go
@@ -386,7 +386,7 @@ func domainWithTrailingDot(withoutDot string) string {
 
 func serviceHostname(service api.Service) (string, error) {
 	ingress := service.Status.LoadBalancer.Ingress
-	fmt.Printf("Service %v", service)
+	fmt.Errorf("Service %v", service)
 	if len(ingress) < 1 {
 		return "", errors.New("No ingress defined for ELB")
 	}

--- a/service_listener.go
+++ b/service_listener.go
@@ -386,6 +386,7 @@ func domainWithTrailingDot(withoutDot string) string {
 
 func serviceHostname(service api.Service) (string, error) {
 	ingress := service.Status.LoadBalancer.Ingress
+	fmt.Printf("Service %v", service)
 	if len(ingress) < 1 {
 		return "", errors.New("No ingress defined for ELB")
 	}

--- a/service_listener.go
+++ b/service_listener.go
@@ -28,7 +28,9 @@ import (
 var dryRun bool
 
 const (
+	// A - dns record type
 	A  = "A"
+	// CNAME - dns record type
 	CNAME = "CNAME"
 )
 

--- a/service_listener.go
+++ b/service_listener.go
@@ -33,7 +33,7 @@ const (
 )
 
 type rule struct {
-	service       	*api.Service
+	service       	api.Service
 	dnsRecordType 	string
 	ttl 		int64
 }
@@ -207,7 +207,7 @@ func getServiceBasedDomainServiceMap(result map[string]rule, c *client.Client, l
 		if ok {
 			domains := strings.Split(annotation, ",")
 			for _, domain := range domains {
-				result[domain] = rule { service: &service, dnsRecordType: dnsRecordType, ttl: ttl }
+				result[domain] = rule { service: service, dnsRecordType: dnsRecordType, ttl: ttl }
 			}
 		} else {
 			glog.Warningf("Domain name not set for %s", service.Name)
@@ -250,7 +250,7 @@ func getIngressBasedDomainServiceMap(result map[string]rule, c *client.Client, l
 		if ok {
 			domains := strings.Split(annotation, ",")
 			for _, domain := range domains {
-				result[domain] = rule{ service: service, dnsRecordType: dnsRecordType, ttl: ttl }
+				result[domain] = rule{ service: *service, dnsRecordType: dnsRecordType, ttl: ttl }
 			}
 		} else {
 			glog.Warningf("Domain name not set for %s", ingress.Name)
@@ -382,7 +382,7 @@ func domainWithTrailingDot(withoutDot string) string {
 	return fmt.Sprint(withoutDot, ".")
 }
 
-func serviceHostname(service *api.Service) (string, error) {
+func serviceHostname(service api.Service) (string, error) {
 	ingress := service.Status.LoadBalancer.Ingress
 	if len(ingress) < 1 {
 		return "", errors.New("No ingress defined for ELB")


### PR DESCRIPTION
## what
* Fixed by bug 


## why
* There was a case where you can have 2 domains point to one service, but should point to 2 different services

## reproducing
How to reproduce:

1. Create 2 exposed services with dns annotations
2. Wait route53 create dns records

## who
@cloudposse/engineering 